### PR TITLE
Fix validation of DID document in did resolver.

### DIFF
--- a/src/common/did-resolver/did-resolver.module.ts
+++ b/src/common/did-resolver/did-resolver.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { DidResolverService } from './did-resolver.service';
 import { RequestModule } from '../request/request.module';
 import { ConfigModule } from '../config/config.module';
+import { LoggerModule } from '../logger/logger.module';
 
 @Module({
-  imports: [RequestModule, ConfigModule],
+  imports: [RequestModule, ConfigModule, LoggerModule],
   providers: [DidResolverService],
   exports: [DidResolverService],
 })

--- a/src/common/did-resolver/did-resolver.service.ts
+++ b/src/common/did-resolver/did-resolver.service.ts
@@ -4,10 +4,26 @@ import { getNetwork, isValidAddress } from '@ltonetwork/lto';
 import { DIDDocument } from './did-document.type';
 import { RequestService } from '../request/request.service';
 import { ConfigService } from '../config/config.service';
+import { LoggerService } from '../logger/logger.service';
 
 @Injectable()
 export class DidResolverService {
-  constructor(private readonly request: RequestService, private readonly config: ConfigService) {}
+  constructor(
+    private readonly request: RequestService,
+    private readonly config: ConfigService,
+    private readonly log: LoggerService,
+  ) {}
+
+  private isDidDocument(didDocument: any): didDocument is DIDDocument {
+    return (
+      didDocument &&
+      (
+        didDocument['@context'] === 'https://www.w3.org/ns/did/v1' ||
+        (Array.isArray(didDocument['@context']) && didDocument['@context'].includes('https://www.w3.org/ns/did/v1'))
+      ) &&
+      typeof didDocument.id === 'string'
+    );
+  }
 
   async resolve(address: string): Promise<DIDDocument | null> {
     if (!isValidAddress(address, 'T') && !isValidAddress(address, 'L')) {
@@ -22,7 +38,7 @@ export class DidResolverService {
     if (response.status !== 200) throw new Error(`Failed to fetch DID document for ${address}`);
 
     const didDocument = response.data;
-    if (didDocument['@context'] !== 'https://www.w3.org/ns/did/v1') {
+    if (!this.isDidDocument(didDocument)) {
       throw new Error(`Invalid DID document for ${address}`);
     }
 
@@ -30,13 +46,17 @@ export class DidResolverService {
   }
 
   async getServiceEndpoint(address: string): Promise<string> {
-    const didDocument = await this.resolve(address);
-    if (!didDocument) return this.config.getDefaultServiceEndpoint();
+    try {
+      const didDocument = await this.resolve(address);
 
-    const service = didDocument.service
-      .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
-      .find((s) => s.type === DID_SERVICE_TYPE);
+      const service = didDocument?.service
+        ?.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+        ?.find((s) => s.type === DID_SERVICE_TYPE);
 
-    return service?.serviceEndpoint ?? this.config.getDefaultServiceEndpoint();
+      return service?.serviceEndpoint ?? this.config.getDefaultServiceEndpoint();
+    } catch (err) {
+      this.log.warn((err as Error).message);
+      return this.config.getDefaultServiceEndpoint();
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,9 +1647,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ltonetwork/lto@npm:^0.16.6":
-  version: 0.16.6
-  resolution: "@ltonetwork/lto@npm:0.16.6"
+"@ltonetwork/lto@npm:^0.15.16":
+  version: 0.15.16
+  resolution: "@ltonetwork/lto@npm:0.15.16"
   dependencies:
     "@noble/curves": ^1.0.0
     "@noble/hashes": ^1.3.0
@@ -1660,7 +1660,7 @@ __metadata:
     crypto-js: ^4.1.1
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
-  checksum: 3a84ba1a37facb06475d36d5b3a0adf96256a9a0cb8df3a3847e88f19dd7eb301ce85358a84d15f8f351c3d4fd235928021894546493cb19ad7e996b0db1b174
+  checksum: 79b33159d48423b2acde32d29acbb8e77bcf74f4727443ff11957aa56b17c08fe5c723917bcaaec3f2e7cee250ecc705d0ce694071aa3ebf855eb8aef6347f2e
   languageName: node
   linkType: hard
 
@@ -1670,7 +1670,7 @@ __metadata:
   dependencies:
     "@aws-sdk/client-s3": ^3.504.0
     "@ltonetwork/http-message-signatures": ^0.1.8
-    "@ltonetwork/lto": ^0.16.6
+    "@ltonetwork/lto": ^0.15.16
     "@nestjs/axios": ^3.0.0
     "@nestjs/cli": ^9.0.0
     "@nestjs/common": ^9.0.0


### PR DESCRIPTION
`@context` can be an array

https://testnet.lto.network/index/identifiers/3N5iXP4b18uEW6M4pctyaAQw2yqfTk3M3iD

```
{
  "@context": [
    "https://www.w3.org/ns/did/v1",
    "https://w3id.org/security/suites/ed25519-2020/v1",
    "https://w3id.org/security/suites/secp256k1-2019/v1 "
  ],
  "id": "did:lto:3N5iXP4b18uEW6M4pctyaAQw2yqfTk3M3iD",
  "verificationMethod": [
    {
      "id": "#sign",
      "type": "Ed25519VerificationKey2020",
      "controller": "did:lto:3N5iXP4b18uEW6M4pctyaAQw2yqfTk3M3iD",
      "publicKeyMultibase": "z13hstVKqZyuKKbYaxaRTJgAJjZHMty5aQvWH3Cur5ct6"
    }
  ],
  "authentication": [
    "#sign"
  ],
  "assertionMethod": [
    "#sign"
  ],
  "keyAgreement": [
    {
      "id": "#encrypt",
      "type": "X25519KeyAgreementKey2019",
      "controller": "did:lto:3N5iXP4b18uEW6M4pctyaAQw2yqfTk3M3iD",
      "publicKeyMultibase": "zwFUa8LVEbqpDS8f9vJBZQoeL5J7mVc8nT3kRcrEHQTw"
    }
  ],
  "capabilityInvocation": [
    "#sign"
  ],
  "capabilityDelegation": [
    "#sign"
  ],
  "service": []
}
```